### PR TITLE
fix(*): move from React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
     "url": "https://github.com/brigand/react-style-proptype/issues"
   },
   "homepage": "https://github.com/brigand/react-style-proptype#readme",
+  "dependencies": {
+    "prop-types": "^15.5.4"
+  },
   "devDependencies": {
     "cheerio": "^0.20.0",
-    "react": "^15.3.2",
     "superagent": "^1.8.3",
     "tape": "^4.5.1"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 var properties = require('./css-properties.js');
-var React = require('react');
+var PropTypes = require('prop-types');
 
 module.exports = function(props, propName, componentName) {
   var styles = props[propName];
@@ -25,8 +25,7 @@ module.exports.isRequired = function(props, propName, componentName) {
   return module.exports(props, propName, componentName);
 };
 
-module.exports.supportingArrays = React.PropTypes.oneOfType([
-  React.PropTypes.arrayOf(module.exports),
+module.exports.supportingArrays = PropTypes.oneOfType([
+  PropTypes.arrayOf(module.exports),
   module.exports
 ]);
-


### PR DESCRIPTION
With React 15.5.x, [React.PropTypes are now extracted to a separated package](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes).