### PR TITLE
Add `user-select` to `properties` array

### DIFF
--- a/src/css-properties.js
+++ b/src/css-properties.js
@@ -1579,5 +1579,10 @@ module.exports = [
   "MozOverflowScrolling",
   "WebkitOverflowScrolling",
   "MSOverflowScrolling",
-  "OOverflowScrolling"
+  "OOverflowScrolling",
+  "userSelect",
+  "MozUserSelect",
+  "WebkitUserSelect",
+  "MSUserSelect",
+  "OUserSelect"
 ]


### PR DESCRIPTION
Thanks for creating this convenient PropType definition.  It sure beats using `PropTypes.object` and getting a CSS property name wrong.

In this fork, I add the `user-select` property.  The `user-select: none` CSS property can be used to prevent the user from selecting text in an element.  My use case for needing this property (can value) was that I'm showing a blurred table of dummy data I don't want the user to be able to interact with by doing things like copying the text within it.

MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/user-select
CanIUse: https://caniuse.com/#search=user-select